### PR TITLE
changed DialogHost to use a TaskCompletionSource (#1163)

### DIFF
--- a/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
+++ b/MaterialDesignThemes.Wpf.Tests/DialogHostTests.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Windows;
+using Xunit;
+
+namespace MaterialDesignThemes.Wpf.Tests
+{
+    public class DialogHostTests : IDisposable
+    {
+        private readonly DialogHost _dialogHost;
+
+        public DialogHostTests()
+        {
+            _dialogHost = new DialogHost();
+            _dialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+        }
+
+        public void Dispose()
+        {
+            _dialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
+        }
+
+        [StaFact(Timeout = 500)]
+        public void CanOpenAndCloseDialogWithIsOpen()
+        {
+            _dialogHost.IsOpen = true;
+            DialogSession session = _dialogHost.CurrentSession;
+            Assert.False(session.IsEnded);
+            _dialogHost.IsOpen = false;
+
+            Assert.False(_dialogHost.IsOpen);
+            Assert.Null(_dialogHost.CurrentSession);
+            Assert.True(session.IsEnded);
+        }
+
+        [StaFact(Timeout = 500)]
+        public async Task CanOpenAndCloseDialogWithShowMethod()
+        {
+            var id = Guid.NewGuid();
+            _dialogHost.Identifier = id;
+
+            object result = await DialogHost.Show("Content", id,
+                new DialogOpenedEventHandler(((sender, args) => { args.Session.Close(42); })));
+
+            Assert.Equal(42, result);
+            Assert.False(_dialogHost.IsOpen);
+        }
+
+        [StaFact(Timeout = 500)]
+        public async Task CanOpenDialogWithShowMethodAndCloseWithIsOpen()
+        {
+            var id = Guid.NewGuid();
+            _dialogHost.Identifier = id;
+
+            object result = await DialogHost.Show("Content", id,
+                new DialogOpenedEventHandler(((sender, args) => { _dialogHost.IsOpen = false; })));
+
+            Assert.Null(result);
+            Assert.False(_dialogHost.IsOpen);
+        }
+
+        [StaFact(Timeout = 500)]
+        public async Task DialogHostExposesSessionAsProperty()
+        {
+            var id = Guid.NewGuid();
+            _dialogHost.Identifier = id;
+
+            await DialogHost.Show("Content", id,
+                new DialogOpenedEventHandler(((sender, args) =>
+                {
+                    Assert.True(ReferenceEquals(args.Session, _dialogHost.CurrentSession));
+                    args.Session.Close();
+                })));
+        }
+
+        [StaFact(Timeout = 500)]
+        public async Task CannotShowDialogWhileItIsAlreadyOpen()
+        {
+            var id = Guid.NewGuid();
+            _dialogHost.Identifier = id;
+
+            await DialogHost.Show("Content", id,
+                new DialogOpenedEventHandler((async (sender, args) =>
+                {
+                    var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => DialogHost.Show("Content", id));
+                    args.Session.Close();
+                    Assert.Equal("DialogHost is already open.", ex.Message);
+                })));
+        }
+
+        [StaFact(Timeout = 500)]
+        public async Task WhenNoDialogsAreOpenItThrows()
+        {
+            var id = Guid.NewGuid();
+            _dialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => DialogHost.Show("Content", id));
+
+            Assert.Equal("No loaded DialogHost instances.", ex.Message);
+        }
+
+        [StaFact(Timeout = 500)]
+        public async Task WhenNoDialogsMatchIdentifierItThrows()
+        {
+            var id = Guid.NewGuid();
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => DialogHost.Show("Content", id));
+
+            Assert.Equal($"No loaded DialogHost have an {nameof(DialogHost.Identifier)} property matching dialogIdentifier argument.", ex.Message);
+        }
+
+        [StaFact(Timeout = 500)]
+        public async Task WhenMultipleDialogHostsHaveTheSameIdentifierItThrows()
+        {
+            var id = Guid.NewGuid();
+            _dialogHost.Identifier = id;
+            var otherDialogHost = new DialogHost { Identifier = id };
+            otherDialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.LoadedEvent));
+
+            var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => DialogHost.Show("Content", id));
+
+            otherDialogHost.RaiseEvent(new RoutedEventArgs(FrameworkElement.UnloadedEvent));
+
+
+            Assert.Equal("Multiple viable DialogHosts.  Specify a unique Identifier on each DialogHost, especially where multiple Windows are a concern.", ex.Message);
+        }
+
+        [StaFact(Timeout = 500)]
+        public async Task WhenNoIdentifierIsSpecifiedItUsesSingleDialogHost()
+        {
+            bool isOpen = false;
+            await DialogHost.Show("Content", new DialogOpenedEventHandler(((sender, args) =>
+            {
+                isOpen = _dialogHost.IsOpen;
+                args.Session.Close();
+            })));
+
+            Assert.True(isOpen);
+        }
+
+        [StaFact(Timeout = 500)]
+        public async Task WhenContentIsNullItThrows()
+        {
+            var ex = await Assert.ThrowsAsync<ArgumentNullException>(() => DialogHost.Show(null));
+            
+            Assert.Equal("content", ex.ParamName);
+        }
+    }
+}

--- a/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
+++ b/MaterialDesignThemes.Wpf.Tests/MaterialDesignThemes.Wpf.Tests.csproj
@@ -31,6 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
@@ -41,6 +43,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DialogHostTests.cs" />
     <Compile Include="PaletteHelperFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
@@ -242,6 +245,38 @@
       <ItemGroup>
         <Reference Include="xunit.execution.dotnet">
           <HintPath>..\packages\xunit.extensibility.execution\lib\netstandard1.1\xunit.execution.dotnet.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Choose>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5'">
+      <ItemGroup>
+        <Reference Include="System.Windows.Forms">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="WindowsBase">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Xunit.StaFact">
+          <HintPath>..\packages\Xunit.StaFact\lib\net45\Xunit.StaFact.dll</HintPath>
+          <Private>True</Private>
+          <Paket>True</Paket>
+        </Reference>
+      </ItemGroup>
+    </When>
+    <When Condition="$(TargetFrameworkIdentifier) == '.NETFramework' And $(TargetFrameworkVersion) == 'v4.5.2'">
+      <ItemGroup>
+        <Reference Include="System.Windows.Forms">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="WindowsBase">
+          <Paket>True</Paket>
+        </Reference>
+        <Reference Include="Xunit.StaFact">
+          <HintPath>..\packages\Xunit.StaFact\lib\net452\Xunit.StaFact.dll</HintPath>
           <Private>True</Private>
           <Paket>True</Paket>
         </Reference>

--- a/MaterialDesignThemes.Wpf.Tests/Properties/AssemblyInfo.cs
+++ b/MaterialDesignThemes.Wpf.Tests/Properties/AssemblyInfo.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using System.Runtime.InteropServices;
+using Xunit;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
@@ -33,3 +34,5 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+[assembly: CollectionBehavior(DisableTestParallelization = true)]

--- a/MaterialDesignThemes.Wpf.Tests/paket.references
+++ b/MaterialDesignThemes.Wpf.Tests/paket.references
@@ -4,3 +4,4 @@ RhinoMocks
 Shouldly
 xunit
 xunit.runner.visualstudio
+Xunit.StaFact

--- a/MaterialDesignThemes.Wpf/DialogHost.cs
+++ b/MaterialDesignThemes.Wpf/DialogHost.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -58,20 +57,18 @@ namespace MaterialDesignThemes.Wpf
 
         private static readonly HashSet<DialogHost> LoadedInstances = new HashSet<DialogHost>();
 
-        private readonly ManualResetEvent _asyncShowWaitHandle = new ManualResetEvent(false);
         private DialogOpenedEventHandler _asyncShowOpenedEventHandler;
         private DialogClosingEventHandler _asyncShowClosingEventHandler;
+        private TaskCompletionSource<object> _dialogTaskCompletionSource;
 
         private Popup _popup;
         private ContentControl _popupContentControl;
         private Grid _contentCoverGrid;
-        private DialogSession _session;
         private DialogOpenedEventHandler _attachedDialogOpenedEventHandler;
         private DialogClosingEventHandler _attachedDialogClosingEventHandler;
-        private object _closeDialogExecutionParameter;
         private IInputElement _restoreFocusDialogClose;
         private IInputElement _restoreFocusWindowReactivation;
-        private Action _currentSnackbarMessageQueueUnPauseAction = null;
+        private Action _currentSnackbarMessageQueueUnPauseAction;
         private Action _closeCleanUp = () => { };
 
         static DialogHost()
@@ -178,7 +175,7 @@ namespace MaterialDesignThemes.Wpf
 
             var targets = LoadedInstances.Where(dh => dialogIdentifier == null || Equals(dh.Identifier, dialogIdentifier)).ToList();
             if (targets.Count == 0)
-                throw new InvalidOperationException("No loaded DialogHost have an Identifier property matching dialogIndetifier argument.");
+                throw new InvalidOperationException($"No loaded DialogHost have an {nameof(Identifier)} property matching {nameof(dialogIdentifier)} argument.");
             if (targets.Count > 1)
                 throw new InvalidOperationException("Multiple viable DialogHosts.  Specify a unique Identifier on each DialogHost, especially where multiple Windows are a concern.");
 
@@ -190,24 +187,21 @@ namespace MaterialDesignThemes.Wpf
             if (IsOpen)
                 throw new InvalidOperationException("DialogHost is already open.");
 
+            
+            _dialogTaskCompletionSource = new TaskCompletionSource<object>();
+
             AssertTargetableContent();
             DialogContent = content;
             _asyncShowOpenedEventHandler = openedEventHandler;
             _asyncShowClosingEventHandler = closingEventHandler;
             SetCurrentValue(IsOpenProperty, true);
-
-            var task = new Task(() =>
-            {
-                _asyncShowWaitHandle.WaitOne();
-            });
-            task.Start();
-
-            await task;
+            
+            object result = await _dialogTaskCompletionSource.Task;
 
             _asyncShowOpenedEventHandler = null;
             _asyncShowClosingEventHandler = null;
 
-            return _closeDialogExecutionParameter;
+            return result;
         }
 
         #endregion
@@ -251,16 +245,19 @@ namespace MaterialDesignThemes.Wpf
             }
             else
             {
-                dialogHost._asyncShowWaitHandle.Set();
                 dialogHost._attachedDialogClosingEventHandler = null;
                 if (dialogHost._currentSnackbarMessageQueueUnPauseAction != null)
                 {
                     dialogHost._currentSnackbarMessageQueueUnPauseAction();
                     dialogHost._currentSnackbarMessageQueueUnPauseAction = null;
                 }
-                dialogHost._session.IsEnded = true;
-                dialogHost._session = null;
+                dialogHost.CurrentSession.IsEnded = true;
+                dialogHost.CurrentSession = null;
                 dialogHost._closeCleanUp();
+                //NB: _dialogTaskCompletionSource is only set in the case where the dialog is shown with Show
+                //To get into this case you need to display the dialog with Show and then hide it by setting IsOpen to false
+                //Setting this here ensures the other 
+                dialogHost._dialogTaskCompletionSource?.TrySetResult(null);
 
                 // Don't attempt to Invoke if _restoreFocusDialogClose hasn't been assigned yet. Can occur
                 // if the MainWindow has started up minimized. Even when Show() has been called, this doesn't
@@ -269,9 +266,8 @@ namespace MaterialDesignThemes.Wpf
 
                 return;
             }
-
-            dialogHost._asyncShowWaitHandle.Reset();
-            dialogHost._session = new DialogSession(dialogHost);
+            
+            dialogHost.CurrentSession = new DialogSession(dialogHost);
             var window = Window.GetWindow(dialogHost);
             dialogHost._restoreFocusDialogClose = window != null ? FocusManager.GetFocusedElement(window) : null;
 
@@ -280,7 +276,7 @@ namespace MaterialDesignThemes.Wpf
             // * the attached property (which should be applied to the button which opened the dialog
             // * straight forward dependency property 
             // * handler provided to the async show method
-            var dialogOpenedEventArgs = new DialogOpenedEventArgs(dialogHost._session, DialogOpenedEvent);
+            var dialogOpenedEventArgs = new DialogOpenedEventArgs(dialogHost.CurrentSession, DialogOpenedEvent);
             dialogHost.OnDialogOpened(dialogOpenedEventArgs);
             dialogHost._attachedDialogOpenedEventHandler?.Invoke(dialogHost, dialogOpenedEventArgs);
             dialogHost.DialogOpenedCallback?.Invoke(dialogHost, dialogOpenedEventArgs);
@@ -300,6 +296,11 @@ namespace MaterialDesignThemes.Wpf
             }));
         }
 
+        /// <summary>
+        /// Returns a DialogSession for the currently open dialog for managing it programmatically. If no dialog is open, CurrentSession will return null
+        /// </summary>
+        public DialogSession CurrentSession { get; private set; }
+
         public bool IsOpen
         {
             get { return (bool)GetValue(IsOpenProperty); }
@@ -311,7 +312,7 @@ namespace MaterialDesignThemes.Wpf
 
         public object DialogContent
         {
-            get { return (object)GetValue(DialogContentProperty); }
+            get { return GetValue(DialogContentProperty); }
             set { SetValue(DialogContentProperty, value); }
         }
 
@@ -384,7 +385,7 @@ namespace MaterialDesignThemes.Wpf
         /// </summary>
         public object CloseOnClickAwayParameter
         {
-            get { return (object)GetValue(CloseOnClickAwayParameterProperty); }
+            get { return GetValue(CloseOnClickAwayParameterProperty); }
             set { SetValue(CloseOnClickAwayParameterProperty, value); }
         }
 
@@ -560,17 +561,17 @@ namespace MaterialDesignThemes.Wpf
 
         internal void AssertTargetableContent()
         {
-            var existindBinding = BindingOperations.GetBindingExpression(this, DialogContentProperty);
-            if (existindBinding != null)
+            var existingBinding = BindingOperations.GetBindingExpression(this, DialogContentProperty);
+            if (existingBinding != null)
                 throw new InvalidOperationException(
                     "Content cannot be passed to a dialog via the OpenDialog if DialogContent already has a binding.");
         }
 
         internal void Close(object parameter)
         {
-            var dialogClosingEventArgs = new DialogClosingEventArgs(_session, parameter, DialogClosingEvent);
+            var dialogClosingEventArgs = new DialogClosingEventArgs(CurrentSession, parameter, DialogClosingEvent);
 
-            _session.IsEnded = true;
+            CurrentSession.IsEnded = true;
 
             //multiple ways of calling back that the dialog is closing:
             // * routed event
@@ -582,12 +583,12 @@ namespace MaterialDesignThemes.Wpf
             DialogClosingCallback?.Invoke(this, dialogClosingEventArgs);
             _asyncShowClosingEventHandler?.Invoke(this, dialogClosingEventArgs);
 
+            _dialogTaskCompletionSource?.TrySetResult(parameter);
+
             if (!dialogClosingEventArgs.IsCancelled)
                 SetCurrentValue(IsOpenProperty, false);
             else
-                _session.IsEnded = false;
-
-            _closeDialogExecutionParameter = parameter;
+                CurrentSession.IsEnded = false;
         }
 
         /// <summary>
@@ -668,7 +669,7 @@ namespace MaterialDesignThemes.Wpf
 
         private void CloseDialogCanExecute(object sender, CanExecuteRoutedEventArgs canExecuteRoutedEventArgs)
         {
-            canExecuteRoutedEventArgs.CanExecute = _session != null;
+            canExecuteRoutedEventArgs.CanExecute = CurrentSession != null;
         }
 
         private void CloseDialogHandler(object sender, ExecutedRoutedEventArgs executedRoutedEventArgs)

--- a/MaterialDesignThemes.Wpf/DialogSession.cs
+++ b/MaterialDesignThemes.Wpf/DialogSession.cs
@@ -8,20 +8,18 @@ namespace MaterialDesignThemes.Wpf
     /// </summary>
     public class DialogSession
     {
-        private readonly DialogHost _owner;    
+        private readonly DialogHost _owner;
 
         internal DialogSession(DialogHost owner)
         {
-            if (owner == null) throw new ArgumentNullException(nameof(owner));
-
-            _owner = owner;
+            _owner = owner ?? throw new ArgumentNullException(nameof(owner));
         }
 
         /// <summary>
         /// Indicates if the dialog session has ended.  Once ended no further method calls will be permitted.
         /// </summary>
         /// <remarks>
-        /// Client code cannot set this directly, this is internally managed.  To end the dicalog session use <see cref="Close()"/>.
+        /// Client code cannot set this directly, this is internally managed.  To end the dialog session use <see cref="Close()"/>.
         /// </remarks>
         public bool IsEnded { get; internal set; }
 
@@ -31,7 +29,7 @@ namespace MaterialDesignThemes.Wpf
         public object Content => _owner.DialogContent;
 
         /// <summary>
-        /// Update the currrent content in the dialog.
+        /// Update the current content in the dialog.
         /// </summary>
         /// <param name="content"></param>
         public void UpdateContent(object content)

--- a/paket.dependencies
+++ b/paket.dependencies
@@ -9,6 +9,7 @@ nuget RhinoMocks 3.6.1
 nuget Shouldly ~> 2.8
 nuget xunit ~> 2.2
 nuget xunit.runner.visualstudio ~> 2.4
+nuget Xunit.StaFact ~> 0.3.13
 nuget ShowMeTheXAML ~> 1.0.12
 nuget ShowMeTheXAML.AvalonEdit ~> 1.0.12
 nuget ShowMeTheXAML.MSBuild ~> 1.0.12

--- a/paket.lock
+++ b/paket.lock
@@ -47,6 +47,9 @@ NUGET
       NETStandard.Library (>= 1.6.1) - restriction: == net45
       xunit.extensibility.core (2.4)
     xunit.runner.visualstudio (2.4)
+    Xunit.StaFact (0.3.13)
+      xunit.extensibility.execution (>= 2.1) - restriction: == net45
+      xunit.extensibility.execution (>= 2.4) - restriction: || (&& (== net45) (>= net452)) (== net452)
 GITHUB
   remote: ControlzEx/ControlzEx
     src/ControlzEx/BadgedEx.cs (e641c9e9346d7ae8c21ca1bf7fa5fb1b86496baa)


### PR DESCRIPTION
* changed DialogHost to use a TaskCompletionSource to await the session end instead of a ManualResetEvent

* DialogHost: expose a public getter for current DialogSession for more convenient programmatic dialog management

* Removing old commented code.
Moving TCS to DialogHost from DialogSession.

* Fixing issue with TCS not being recreated

* Adding unit tests for the DialogHost.
Fixing issue that could occur if the DialogHost was opened with the static Show method and closed with its IsOpen